### PR TITLE
[Bugfix] Work fine with io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - iojs
 
 script:
   - npm test

--- a/lib/database.js
+++ b/lib/database.js
@@ -90,7 +90,7 @@ Database.prototype.load = function(callback){
   if (!path) throw new WarehouseError('options.path is required');
 
   return new Promise(function(resolve, reject){
-    var src = fs.createReadStream(path, 'utf8');
+    var src = fs.createReadStream(path, {encoding: 'utf8'});
     var oldVersion = 0;
 
     var stream = JSONStream.parse([true, true], function(value, keys){


### PR DESCRIPTION
I found a bug.

The second argument of fs.createReadStream() must be object. but it's string in v1.0.1.

io.js use this value as prototype of new object (see https://github.com/iojs/io.js/blob/v1.x/lib/fs.js ), so error occurs.

I think this is why hexo's tests failed.